### PR TITLE
fix sqlite

### DIFF
--- a/src/python/plaid2text/storage_manager.py
+++ b/src/python/plaid2text/storage_manager.py
@@ -178,8 +178,7 @@ class SQLiteStorage():
 
             t['date'] = date_parser.parse( t['date'] )        
 
-            entry = Entry(t, {})
-            ret.append( entry )
+            ret.append(t)
 
         return ret
 


### PR DESCRIPTION
The sqlite db option doesnt seem to be working:

Note, for example that an Entry is created here on line 182 with an empty {} as an argument:
https://github.com/madhat2r/plaid2text/blob/1a37be135836b89c2351c0c1945346bab578eec4/src/python/plaid2text/storage_manager.py#L175-L185

But that will always fail, because Entry checks a field 'currency', which will never be populated:
https://github.com/madhat2r/plaid2text/blob/1a37be135836b89c2351c0c1945346bab578eec4/src/python/plaid2text/renderers.py#L47